### PR TITLE
feat: add extra_filetypes table in opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,27 @@ Options:
 - `highlights`: override highlight specs by semantic key.
 - `map_gx`: map `gx` in Markdown buffers to `:MarkdownTableOpenLink` with fallback to native `gx`.
 - `link`: icon configuration for links, wiki links, images, and URL pattern matches.
+- `extra_filetypes`: list of additional filetypes to enable table rendering for. The default is `{}`, meaning only `markdown`, `md`, `quarto`, and `rmarkdown` buffers render tables.
+
+```lua
+require("markdown-table-wrap").setup({
+  extra_filetypes = { "text" },
+})
+```
+
+> **Note for LazyVim users:** If you add extra filetypes, you must also include them in the plugin's `ft` list to load the plugin for those filetypes:
+>
+> ```lua
+> return {
+>   {
+>     "ice345/markdown-table-wrap.nvim",
+>     ft = { "markdown", "text" },
+>     opts = {
+>       extra_filetypes = { "text" },
+>     },
+>   },
+> }
+> ```
 
 Highlight override example:
 

--- a/doc/markdown-table-wrap.txt
+++ b/doc/markdown-table-wrap.txt
@@ -259,6 +259,30 @@ map_gx~
     native gx. This avoids opening the concealed source word under rendered
     virtual text, such as trying to open "Details" instead of the source URL.
 
+extra_filetypes~
+    List of additional filetypes to enable table rendering for. The default
+    is {}, meaning only markdown, md, quarto, and rmarkdown buffers
+    render tables. Example:
+>
+      require("markdown-table-wrap").setup({
+        extra_filetypes = { "text" },
+      })
+<
+    NOTE for LazyVim users: If you add extra filetypes, you must also
+    include them in the plugin's ft list to load the plugin for those
+    filetypes:
+>
+      return {
+        {
+          "ice345/markdown-table-wrap.nvim",
+          ft = { "markdown", "text" },
+          opts = {
+            extra_filetypes = { "text" },
+          },
+        },
+      }
+<
+
 ==============================================================================
 HIGHLIGHTS                                  *markdown-table-wrap-highlights*
 

--- a/lua/markdown-table-wrap/init.lua
+++ b/lua/markdown-table-wrap/init.lua
@@ -78,6 +78,21 @@ local function validate_config()
   M.config.inline_viewport_scrolling = M.config.inline_viewport_scrolling ~= false
   M.config.map_gx = M.config.map_gx ~= false
 
+  if type(M.config.extra_filetypes) ~= "table" or #M.config.extra_filetypes == 0 then
+    M.config.extra_filetypes = {}
+  else
+    local valid = true
+    for _, v in ipairs(M.config.extra_filetypes) do
+      if type(v) ~= "string" then
+        valid = false
+        break
+      end
+    end
+    if not valid then
+      M.config.extra_filetypes = {}
+    end
+  end
+
   if M.config.inline_virtual_text ~= "overlay" and M.config.inline_virtual_text ~= "win_col" then
     M.config.inline_virtual_text = defaults.inline_virtual_text
   end

--- a/lua/markdown-table-wrap/init.lua
+++ b/lua/markdown-table-wrap/init.lua
@@ -29,6 +29,7 @@ local defaults = {
   highlight_preset = "default",
   theme_dir = nil,
   themes = {},
+  extra_filetypes = {},
   highlights = {},
   map_gx = true,
   link = {
@@ -60,7 +61,8 @@ M.state = {
 
 local function is_markdown_buffer()
   local ft = vim.bo.filetype
-  return ft == "markdown" or ft == "md" or ft == "quarto" or ft == "rmarkdown"
+  local extra = M.config.extra_filetypes or {}
+  return ft == "markdown" or ft == "md" or ft == "quarto" or ft == "rmarkdown" or vim.tbl_contains(extra, ft)
 end
 
 local function validate_config()
@@ -178,7 +180,7 @@ local function table_under_cursor(opts)
 
   if not is_markdown_buffer() then
     if not opts.silent then
-      vim.notify("MarkdownTableWrap: preview is only available in Markdown buffers.", vim.log.levels.INFO)
+      vim.notify("MarkdownTableWrap: preview is only available in Markdown buffers or fts added to extra_filetypes in opts.", vim.log.levels.INFO) 
     end
     return nil
   end
@@ -524,8 +526,13 @@ local function create_autocmds()
 
   vim.api.nvim_create_autocmd("FileType", {
     group = M.state.augroup,
-    pattern = { "markdown", "md", "quarto", "rmarkdown" },
+    pattern = "*",
     callback = function(args)
+      local fts = { "markdown", "md", "quarto", "rmarkdown" }
+      vim.list_extend(fts, M.config.extra_filetypes or {})
+      if not vim.tbl_contains(fts, vim.bo[args.buf].filetype) then
+        return
+      end
       if not M.config.map_gx then
         return
       end

--- a/tests/spec/system_spec.lua
+++ b/tests/spec/system_spec.lua
@@ -77,3 +77,64 @@ h.test("plugin loader does not override manual setup", function()
   h.assert_eq("manual highlight_preset preserved", plugin.config.highlight_preset, "default")
   h.assert_false("manual viewport preference preserved", plugin.config.inline_viewport_scrolling)
 end)
+
+h.test("extra_filetypes renders in configured filetype", function()
+  local plugin = require("markdown-table-wrap")
+  local inline = require("markdown-table-wrap.inline")
+
+  plugin.setup({
+    debounce_ms = 0,
+    render_all = true,
+    auto_preview = true,
+    max_col_width = 14,
+    min_col_width = 4,
+    extra_filetypes = { "text" },
+  })
+
+  h.with_buffer({
+    "| A | B |",
+    "| --- | --- |",
+    "| foo | bar |",
+  }, function(buf)
+    vim.bo[buf].filetype = "text"
+    plugin.refresh_auto({ force = true })
+
+    local marks = vim.api.nvim_buf_get_extmarks(buf, inline.namespace(), 0, -1, { details = true })
+    local rendered = #marks > 0
+
+    h.assert_true("table rendered in extra_filetype text", rendered)
+
+    inline.clear(buf)
+  end)
+end)
+
+h.test("non-configured filetypes are ignored", function()
+  local plugin = require("markdown-table-wrap")
+  local inline = require("markdown-table-wrap.inline")
+
+
+  plugin.setup({
+    debounce_ms = 0,
+    render_all = true,
+    auto_preview = true,
+    max_col_width = 14,
+    min_col_width = 4,
+    extra_filetypes = { "text" },
+  })
+
+  h.with_buffer({
+    "| A | B |",
+    "| --- | --- |",
+    "| foo | bar |",
+  }, function(buf)
+    vim.bo[buf].filetype = "python"
+    plugin.refresh_auto({ force = true })
+
+    local marks = vim.api.nvim_buf_get_extmarks(buf, inline.namespace(), 0, -1, { details = true })
+    local rendered = #marks > 0
+
+    h.assert_false("table not rendered in non-configured filetype", rendered)
+
+    inline.clear(buf)
+  end)
+end)


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->
I have added a extra_filetypes in opts so that we can extend the plugin for other filetypes aside from markdown files that follows the same format/syntax (in my case, im using it for codecompanion).

## Testing

<!-- Paste test output or describe manual checks. -->

- [x] `nvim --headless -u NONE --cmd "set shadafile=NONE" --cmd "set noswapfile" -c "set rtp+=." -c "luafile tests/run.lua" -c "qa!"`
<img width="789" height="167" alt="image" src="https://github.com/user-attachments/assets/efcadfd3-cbe9-4150-ad08-dd35146f0b73" />

- [x] Manual Markdown table render check
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ece4c57e-11dc-41b1-a111-06936d655fc2" />

- [x] `:checkhealth markdown-table-wrap`
<img width="962" height="334" alt="image" src="https://github.com/user-attachments/assets/58920ab9-12a2-4f8c-8580-342d866e68b5" />

