### PR TITLE
fix: keep Reader and Inline scroll across native buffer switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to `markdown-table-wrap.nvim` are documented here.
 
 ### Fixed
 
+- Keep Reader cursor and window scroll across native buffer switches
+  (`:Buffers`, `:bnext`, Telescope, and similar) by mapping the rendered
+  viewport onto Source on leave and restoring it when Reader reopens.
+- Preserve Inline window scroll when wrap/conceal options are restored on
+  `BufLeave`/`BufWinEnter`.
 - Guard Reader's `y` and `d` cell prefixes so mistyped motions such as
   `yj`/`yk` cannot yank rendered borders and `dj`/`dk`/`dd` cannot raise E21;
   cancellation preserves the cursor, registers, Reader, and Source.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -132,8 +132,9 @@ several tables, links, escaped pipes, code spans, and mixed CJK/English text.
 - Wipe a rendered buffer and confirm reopening a document does not inherit stale
   viewport, timer, or view state.
 - Leave an automatically opened Reader through native buffer navigation, return
-  to its Source, and confirm Reader reopens. Explicit close/edit must still
-  report `paused=true` and remain in Source.
+  to its Source, and confirm Reader reopens at the previous cursor and scroll
+  position. Explicit close/edit must still report `paused=true` and remain in
+  Source.
 - Run `tests/benchmark.lua`, compare all scenarios with
   `docs/performance.md`, and inspect the selected discovery backend and cache
   stages with `:MarkdownTableInspect`.

--- a/README.md
+++ b/README.md
@@ -304,9 +304,11 @@ The tested Vim-semantics contract is:
 
 Native buffer/window navigation only dismisses the disposable Reader view. It
 does not set the Source pause flag, so returning to that Source applies the
-normal automatic Reader policy again. Explicit close, Source edit, disabling
-auto-preview, or switching view does set the corresponding persistent user
-intent.
+normal automatic Reader policy again. The Reader cursor and window scroll are
+written onto Source on leave and restored when Reader reopens, including
+wrapped-table row offsets when Source has not moved. Explicit close, Source
+edit, disabling auto-preview, or switching view does set the corresponding
+persistent user intent.
 
 ### Choosing A View
 

--- a/doc/markdown-table-wrap.txt
+++ b/doc/markdown-table-wrap.txt
@@ -84,8 +84,9 @@ Default interaction:
   target it delegates to the Source mapping captured when Reader opened, or to
   native gx when available. Source-buffer gx is left untouched by default;
   native buffer/window navigation dismisses Reader without pausing Source, so
-  returning to an auto-preview Source restores Reader. Explicit close/edit or
-  disable actions keep their persistent pause semantics.
+  returning to an auto-preview Source restores Reader at the previous cursor
+  and window scroll. Explicit close/edit or disable actions keep their
+  persistent pause semantics.
   see |markdown-table-wrap-map-gx|.
 
 CELL OPERATIONS                              *markdown-table-wrap-cell-operations*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -271,8 +271,12 @@ Source paused ──explicit preview/enable──► rendered view, pause cleare
 ```
 
 Native Reader `BufHidden` cleanup calls `reader.abandon()` and deletes only the
-disposable view. It must not set the Source pause flag. When the Source next
-enters a window, the normal debounced auto-preview policy runs again.
+disposable view. It must not set the Source pause flag. Before the scratch
+buffer is dropped, the Reader cursor, `topline`, and wrap offsets are mapped
+onto Source and stored per window. When the Source next enters a window, that
+viewport is applied first and the normal debounced auto-preview policy reopens
+Reader at the same place. Inline wrap/conceal attach and detach remember and
+restore `winsaveview()` so native buffer switches do not reset scroll.
 
 ## Lifecycle And Scheduling
 
@@ -291,20 +295,23 @@ Readers or recompute Inline. Resize events fan out to every affected visible
 Reader and schedule each distinct visible Source/Inline buffer once, instead of
 depending on whichever window happened to be current. Buffer wipe releases
 Reader/Inline state, caches, discovery status, mappings, pause state, viewport
-state, and scheduled tokens. Window close restores Inline-owned options.
+state, saved window views, and scheduled tokens. Window close restores
+Inline-owned options and drops per-window saved views.
 
-Reader open snapshots Source cursor/window options, builds the complete derived
-document, prepares a scratch buffer, and sets Source `bufhidden` to `hide` while
-dependent Readers exist before switching the window to that unlisted protected
-view. Build, scratch preparation, window transition, and final window
+Reader open snapshots Source cursor, window scroll, and window options, builds
+the complete derived document, prepares a scratch buffer, and sets Source
+`bufhidden` to `hide` while dependent Readers exist before switching the window
+to that unlisted protected view. Auto-reopen after a native leave prefers the
+saved Source-mapped viewport over the window's stale last-view of Source.
+Build, scratch preparation, window transition, and final window
 configuration are guarded stages. A failed stage restores Source
 ownership/options and deletes the disposable scratch buffer. Refresh builds
 against a copied configuration and commits lines, indexes, configuration, and
 changedtick together; a failed projection update restores the previous
 lines/overlay and always protects the Reader as non-modifiable. Explicit close
-maps the Reader cursor back to Source, restores options and ownership, and
-deletes the scratch buffer. `:write` in Reader delegates to the Source through
-`BufWriteCmd`; the Reader never owns edits.
+maps the Reader cursor and scroll back to Source, restores options and ownership,
+and deletes the scratch buffer. `:write` in Reader delegates to the Source
+through `BufWriteCmd`; the Reader never owns edits.
 
 Cell changes are the exception to the general “Reader is protected” rule only
 in terms of their entry point: the Reader remains non-modifiable, while

--- a/lua/markdown-table-wrap/init.lua
+++ b/lua/markdown-table-wrap/init.lua
@@ -391,7 +391,7 @@ function M.reader_preview(opts)
   M.state.inline_buf = nil
   M.state.last_signature[bufnr] = nil
   M.state.paused_buffers[bufnr] = nil
-  return reader.open(bufnr, config_for_buffer(bufnr))
+  return reader.open(bufnr, config_for_buffer(bufnr), { auto = opts.auto == true })
 end
 
 function M.pause_buffer(bufnr)
@@ -810,6 +810,8 @@ local function create_autocmds()
         reader.update_sticky_header(args.buf)
         return
       end
+      reader.invalidate_source_view(args.buf, vim.api.nvim_get_current_win())
+      require("markdown-table-wrap.inline").invalidate_window_view(args.buf, vim.api.nvim_get_current_win())
       if not is_markdown_buffer(args.buf) then
         return
       end
@@ -838,6 +840,7 @@ local function create_autocmds()
       if not is_markdown_buffer(bufnr) then
         return
       end
+      require("markdown-table-wrap.reader").invalidate_source_view(bufnr)
       if args.event == "TextChanged" or args.event == "TextChangedI" or args.event == "InsertLeave" then
         if require("markdown-table-wrap.reader").refresh_source(bufnr) > 0 then
           return
@@ -847,7 +850,11 @@ local function create_autocmds()
       if vim.api.nvim_win_get_buf(winid) ~= bufnr then
         winid = nil
       end
-      M.schedule_refresh({ bufnr = bufnr, winid = winid, silent = true })
+      M.schedule_refresh({
+        bufnr = bufnr,
+        winid = winid,
+        silent = true,
+      })
     end,
   })
 
@@ -931,7 +938,20 @@ local function create_autocmds()
   vim.api.nvim_create_autocmd({ "WinEnter", "BufWinEnter" }, {
     group = M.state.augroup,
     callback = function(args)
-      require("markdown-table-wrap.inline").attach_window(args.buf)
+      local bufnr = args.buf
+      local targets
+      if args.event == "WinEnter" then
+        targets = { vim.api.nvim_get_current_win() }
+      else
+        targets = vim.fn.win_findbuf(bufnr)
+        if #targets == 0 then
+          targets = { vim.api.nvim_get_current_win() }
+        end
+      end
+      for _, winid in ipairs(targets) do
+        require("markdown-table-wrap.inline").attach_window(bufnr, { restore_view = true, winid = winid })
+        require("markdown-table-wrap.reader").restore_source_view(bufnr, winid)
+      end
     end,
   })
 
@@ -988,7 +1008,10 @@ local function create_autocmds()
   vim.api.nvim_create_autocmd("WinClosed", {
     group = M.state.augroup,
     callback = function(args)
-      require("markdown-table-wrap.inline").detach_window(tonumber(args.match))
+      local winid = tonumber(args.match)
+      require("markdown-table-wrap.inline").detach_window(winid)
+      require("markdown-table-wrap.inline").clear_window_views(winid)
+      require("markdown-table-wrap.reader").clear_saved_views(nil, winid)
     end,
   })
 
@@ -1033,6 +1056,7 @@ function M.setup(opts)
   M.state.last_signature = {}
   M.state.visual_buffers = {}
   M.state.inline_buf = nil
+  require("markdown-table-wrap.reader").clear_saved_views()
   create_autocmds()
   require("markdown-table-wrap.commands").register(M)
   require("markdown-table-wrap.theme").apply(M.config)

--- a/lua/markdown-table-wrap/inline.lua
+++ b/lua/markdown-table-wrap/inline.lua
@@ -10,6 +10,7 @@ local active_buffers = {}
 local active_tables = {}
 local active_configs = {}
 local view_offsets = {}
+local saved_window_views = {}
 
 local function normalize_bufnr(bufnr)
   if not bufnr or bufnr == 0 then
@@ -369,6 +370,35 @@ local function show_insert(bufnr, table_info, config, rendered)
   end
 end
 
+local function window_has_owned_options(winid)
+  return saved_conceallevels[winid] ~= nil
+    or saved_concealcursors[winid] ~= nil
+    or saved_wraps[winid] ~= nil
+end
+
+local function snapshot_window_view(bufnr, winid)
+  winid = winid or vim.api.nvim_get_current_win()
+  if not vim.api.nvim_win_is_valid(winid) or vim.api.nvim_win_get_buf(winid) ~= bufnr then
+    return nil, winid
+  end
+  local ok, view = pcall(vim.api.nvim_win_call, winid, function()
+    return vim.fn.winsaveview()
+  end)
+  if ok and type(view) == "table" then
+    return view, winid
+  end
+  return nil, winid
+end
+
+local function restore_view_dict(winid, view)
+  if not view or not winid or not vim.api.nvim_win_is_valid(winid) then
+    return false
+  end
+  return pcall(vim.api.nvim_win_call, winid, function()
+    vim.fn.winrestview(view)
+  end)
+end
+
 function M.clear(bufnr)
   bufnr = normalize_bufnr(bufnr)
 
@@ -384,6 +414,23 @@ end
 
 function M.detach_window(winid)
   winid = winid or vim.api.nvim_get_current_win()
+  if vim.api.nvim_win_is_valid(winid) and window_has_owned_options(winid) then
+    local bufnr = vim.api.nvim_win_get_buf(winid)
+    local ok, view = pcall(vim.api.nvim_win_call, winid, function()
+      return vim.fn.winsaveview()
+    end)
+    if ok and type(view) == "table" then
+      saved_window_views[bufnr] = saved_window_views[bufnr] or {}
+      local previous = saved_window_views[bufnr][winid]
+      if not previous or previous.applied then
+        saved_window_views[bufnr][winid] = {
+          view = view,
+          changedtick = vim.api.nvim_buf_get_changedtick(bufnr),
+          applied = false,
+        }
+      end
+    end
+  end
   restore_render_window(winid)
 end
 
@@ -391,6 +438,7 @@ function M.dispose(bufnr)
   bufnr = normalize_bufnr(bufnr)
   M.clear(bufnr)
   view_offsets[bufnr] = nil
+  saved_window_views[bufnr] = nil
 end
 
 function M.reset_view(bufnr)
@@ -421,6 +469,8 @@ local function show_one(bufnr, table_info, config)
 end
 
 function M.show(bufnr, table_info, config)
+  bufnr = normalize_bufnr(bufnr)
+  local view, winid = snapshot_window_view(bufnr)
   ensure_highlights(config)
   M.clear(bufnr)
 
@@ -431,10 +481,13 @@ function M.show(bufnr, table_info, config)
   if config.inline_mode == "replace" then
     set_render_for_buffer(bufnr, config)
   end
+  restore_view_dict(winid, view)
   return rendered
 end
 
 function M.show_many(bufnr, tables, config)
+  bufnr = normalize_bufnr(bufnr)
+  local view, winid = snapshot_window_view(bufnr)
   ensure_highlights(config)
   M.clear(bufnr)
 
@@ -449,6 +502,7 @@ function M.show_many(bufnr, tables, config)
   if config.inline_mode == "replace" then
     set_render_for_buffer(bufnr, config)
   end
+  restore_view_dict(winid, view)
   return rendered
 end
 
@@ -519,10 +573,103 @@ function M.scroll_to(bufnr, position)
   return true
 end
 
-function M.attach_window(bufnr)
+function M.attach_window(bufnr, opts)
+  opts = opts or {}
   bufnr = normalize_bufnr(bufnr)
+  local winid = opts.winid or vim.api.nvim_get_current_win()
   if active_buffers[bufnr] and (active_configs[bufnr] or {}).inline_mode == "replace" then
     set_render_for_buffer(bufnr, active_configs[bufnr] or {})
+  end
+  if opts.restore_view then
+    M.restore_window_view(bufnr, winid)
+  end
+end
+
+function M.restore_window_view(bufnr, winid)
+  bufnr = normalize_bufnr(bufnr)
+  winid = winid or vim.api.nvim_get_current_win()
+  local by_win = saved_window_views[bufnr]
+  local saved = by_win and by_win[winid]
+  if not saved then
+    return false
+  end
+  local view = saved.view or saved
+  if type(saved) == "table" and saved.applied then
+    return false
+  end
+  if type(saved) == "table" and saved.changedtick and vim.api.nvim_buf_is_valid(bufnr) then
+    if saved.changedtick ~= vim.api.nvim_buf_get_changedtick(bufnr) then
+      by_win[winid] = nil
+      if next(by_win) == nil then
+        saved_window_views[bufnr] = nil
+      end
+      return false
+    end
+  end
+  if not view or not vim.api.nvim_win_is_valid(winid) then
+    return false
+  end
+  if vim.api.nvim_win_get_buf(winid) ~= bufnr then
+    return false
+  end
+  local ok = pcall(vim.api.nvim_win_call, winid, function()
+    vim.fn.winrestview(view)
+  end)
+  if ok then
+    by_win[winid] = nil
+    if next(by_win) == nil then
+      saved_window_views[bufnr] = nil
+    end
+  end
+  return ok
+end
+
+function M.invalidate_window_view(bufnr, winid)
+  bufnr = normalize_bufnr(bufnr)
+  winid = tonumber(winid) or vim.api.nvim_get_current_win()
+  local by_win = saved_window_views[bufnr]
+  local saved = by_win and by_win[winid]
+  if type(saved) ~= "table" or not saved.view then
+    return false
+  end
+  if saved.changedtick and vim.api.nvim_buf_is_valid(bufnr) then
+    if saved.changedtick ~= vim.api.nvim_buf_get_changedtick(bufnr) then
+      by_win[winid] = nil
+      if next(by_win) == nil then
+        saved_window_views[bufnr] = nil
+      end
+      return true
+    end
+  end
+  if not vim.api.nvim_win_is_valid(winid) or vim.api.nvim_win_get_buf(winid) ~= bufnr then
+    return false
+  end
+  local ok, view = pcall(vim.api.nvim_win_call, winid, function()
+    return vim.fn.winsaveview()
+  end)
+  if not ok or type(view) ~= "table" then
+    return false
+  end
+  if view.lnum ~= saved.view.lnum then
+    by_win[winid] = nil
+    if next(by_win) == nil then
+      saved_window_views[bufnr] = nil
+    end
+    return true
+  end
+  return false
+end
+
+function M.clear_window_views(winid)
+  winid = tonumber(winid)
+  if not winid then
+    return
+  end
+  for bufnr, by_win in pairs(saved_window_views) do
+    by_win[winid] = nil
+    if next(by_win) == nil then
+      saved_window_views[bufnr] = nil
+    end
   end
 end
 

--- a/lua/markdown-table-wrap/reader.lua
+++ b/lua/markdown-table-wrap/reader.lua
@@ -7,6 +7,9 @@ local namespace = vim.api.nvim_create_namespace("markdown-table-wrap-reader")
 local visual_namespace = vim.api.nvim_create_namespace("markdown-table-wrap-reader-visual")
 local states = {}
 local source_states = {}
+-- Per-Source, per-window Reader viewport written on native leave so auto-reopen
+-- can restore cursor/topline after the disposable scratch buffer is deleted.
+local saved_views = {}
 
 local function notify_error(action, err)
   vim.notify("MarkdownTableWrap: " .. action .. ": " .. tostring(err), vim.log.levels.ERROR)
@@ -353,6 +356,12 @@ local function create_reader_buffer(source_bufnr)
     )
 
     vim.bo[reader_bufnr].filetype = vim.bo[source_bufnr].filetype
+    vim.api.nvim_create_autocmd("BufWinLeave", {
+      buffer = reader_bufnr,
+      callback = function()
+        require("markdown-table-wrap.reader").sync_view(reader_bufnr)
+      end,
+    })
     vim.api.nvim_create_autocmd("BufHidden", {
       buffer = reader_bufnr,
       once = true,
@@ -404,6 +413,340 @@ local function source_cursor_for(state, reader_lnum, reader_col)
   return source_lnum, source_col
 end
 
+local function clamp_lnum(bufnr, lnum)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return 1
+  end
+  return math.max(1, math.min(tonumber(lnum) or 1, vim.api.nvim_buf_line_count(bufnr)))
+end
+
+local function wrap_offset(mapping, reader_lnum, source_lnum)
+  local first = mapping and mapping[source_lnum]
+  if not first then
+    return 0
+  end
+  return math.max(0, (tonumber(reader_lnum) or 1) - first)
+end
+
+local function last_reader_line_for_source(built, source_lnum)
+  local first = built.source_to_reader[source_lnum]
+  if not first then
+    return nil
+  end
+  local last = first
+  for reader_lnum = first + 1, #(built.lines or {}) do
+    if built.reader_to_source[reader_lnum] ~= source_lnum then
+      break
+    end
+    last = reader_lnum
+  end
+  return last
+end
+
+local function map_source_line(built, source_lnum, offset)
+  local last_line = math.max(1, #(built.lines or {}))
+  local first = built.source_to_reader[source_lnum]
+  if not first then
+    return math.max(1, math.min(tonumber(source_lnum) or 1, last_line))
+  end
+  local last = last_reader_line_for_source(built, source_lnum) or first
+  return math.max(1, math.min(first + (tonumber(offset) or 0), last, last_line))
+end
+
+local function view_extras(view)
+  if type(view) ~= "table" then
+    return { leftcol = 0, coladd = 0 }
+  end
+  local extras = {
+    leftcol = tonumber(view.leftcol) or 0,
+    coladd = tonumber(view.coladd) or 0,
+  }
+  if view.curswant ~= nil then
+    extras.curswant = view.curswant
+  end
+  if view.skipcol ~= nil then
+    extras.skipcol = view.skipcol
+  end
+  if view.topfill ~= nil then
+    extras.topfill = view.topfill
+  end
+  return extras
+end
+
+local function with_view_extras(base, view)
+  for key, value in pairs(view_extras(view)) do
+    if base[key] == nil then
+      base[key] = value
+    end
+  end
+  return base
+end
+
+local function snapshot_changedtick_matches(saved, source_bufnr)
+  if not saved or not saved.source_changedtick or not vim.api.nvim_buf_is_valid(source_bufnr) then
+    return false
+  end
+  return saved.source_changedtick == vim.api.nvim_buf_get_changedtick(source_bufnr)
+end
+
+local function source_view_matches_snapshot(source_view, saved)
+  return saved and tonumber(source_view.lnum) == tonumber(saved.source_lnum)
+end
+
+local function reader_winid(state, reader_bufnr)
+  local winid = state and state.winid
+  if winid and vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == reader_bufnr then
+    return winid
+  end
+  return vim.fn.win_findbuf(reader_bufnr)[1]
+end
+
+local function get_saved_view(source_bufnr, winid)
+  local by_win = saved_views[source_bufnr]
+  return by_win and by_win[winid] or nil
+end
+
+local function store_saved_view(source_bufnr, winid, view)
+  if not source_bufnr or not winid or not view then
+    return
+  end
+  saved_views[source_bufnr] = saved_views[source_bufnr] or {}
+  saved_views[source_bufnr][winid] = view
+end
+
+local function clear_saved_view(source_bufnr, winid)
+  if not source_bufnr then
+    return
+  end
+  if not winid then
+    saved_views[source_bufnr] = nil
+    return
+  end
+  local by_win = saved_views[source_bufnr]
+  if not by_win then
+    return
+  end
+  by_win[winid] = nil
+  if next(by_win) == nil then
+    saved_views[source_bufnr] = nil
+  end
+end
+
+local function source_winrestview(view, source_bufnr)
+  local lnum = clamp_lnum(source_bufnr, view.source_lnum or view.lnum)
+  local topline = clamp_lnum(source_bufnr, view.source_topline or view.topline or lnum)
+  if topline > lnum then
+    topline = lnum
+  end
+  local line = vim.api.nvim_buf_get_lines(source_bufnr, lnum - 1, lnum, false)[1] or ""
+  local col = math.max(0, math.min(tonumber(view.source_col or view.col) or 0, #line))
+  return with_view_extras({
+    lnum = lnum,
+    col = col,
+    topline = topline,
+  }, view)
+end
+
+local function capture_view(reader_bufnr, winid)
+  local state = states[reader_bufnr]
+  if not state or not vim.api.nvim_buf_is_valid(state.source_bufnr) then
+    return nil
+  end
+  winid = winid or reader_winid(state, reader_bufnr)
+  if not winid or not vim.api.nvim_win_is_valid(winid) or vim.api.nvim_win_get_buf(winid) ~= reader_bufnr then
+    return nil
+  end
+
+  local ok, view = pcall(vim.api.nvim_win_call, winid, function()
+    return vim.fn.winsaveview()
+  end)
+  if not ok or type(view) ~= "table" then
+    return nil
+  end
+
+  local source_lnum, source_col = source_cursor_for(state, view.lnum, view.col)
+  local source_topline = state.reader_to_source[view.topline] or source_lnum
+  local captured = with_view_extras({
+    source_lnum = source_lnum,
+    source_col = source_col,
+    source_topline = source_topline,
+    cursor_offset = wrap_offset(state.source_to_reader, view.lnum, source_lnum),
+    topline_offset = wrap_offset(state.source_to_reader, view.topline, source_topline),
+    source_changedtick = vim.api.nvim_buf_get_changedtick(state.source_bufnr),
+    winid = winid,
+    applied = false,
+  }, view)
+  return captured
+end
+
+local function apply_source_view(source_bufnr, winid, view)
+  if not view or not vim.api.nvim_buf_is_valid(source_bufnr) then
+    return false
+  end
+  if not winid or not vim.api.nvim_win_is_valid(winid) then
+    return false
+  end
+  if vim.api.nvim_win_get_buf(winid) ~= source_bufnr then
+    return false
+  end
+  local restored = source_winrestview(view, source_bufnr)
+  return pcall(vim.api.nvim_win_call, winid, function()
+    vim.fn.winrestview(restored)
+  end)
+end
+
+local function restore_reader_view(winid, built, source_view)
+  if not winid or not vim.api.nvim_win_is_valid(winid) or type(built) ~= "table" or type(source_view) ~= "table" then
+    return
+  end
+
+  local cursor_offset = source_view.cursor_offset
+  local topline_offset = source_view.topline_offset
+  if not built.source_to_reader[source_view.lnum] then
+    cursor_offset = 0
+  end
+  if not built.source_to_reader[source_view.topline] then
+    topline_offset = 0
+  end
+
+  local reader_lnum = map_source_line(built, source_view.lnum, cursor_offset)
+  local reader_topline = map_source_line(built, source_view.topline, topline_offset)
+  if reader_lnum < reader_topline then
+    reader_topline = reader_lnum
+  end
+  local line = built.lines[reader_lnum] or ""
+  local col = math.max(0, math.min(tonumber(source_view.col) or 0, #line))
+  pcall(vim.api.nvim_win_call, winid, function()
+    vim.fn.winrestview(with_view_extras({
+      lnum = reader_lnum,
+      col = col,
+      topline = reader_topline,
+    }, source_view))
+  end)
+end
+
+function M.clear_saved_views(bufnr, winid)
+  bufnr = tonumber(bufnr)
+  winid = tonumber(winid)
+  if bufnr then
+    clear_saved_view(bufnr, winid)
+    return
+  end
+  if not winid then
+    saved_views = {}
+    return
+  end
+  for source_bufnr, by_win in pairs(saved_views) do
+    by_win[winid] = nil
+    if next(by_win) == nil then
+      saved_views[source_bufnr] = nil
+    end
+  end
+end
+
+function M.sync_view(reader_bufnr)
+  reader_bufnr = normalize_bufnr(reader_bufnr)
+  local state = states[reader_bufnr]
+  if not state or state.closing then
+    return false
+  end
+
+  local winid = vim.api.nvim_get_current_win()
+  local view = capture_view(reader_bufnr, winid) or capture_view(reader_bufnr, state.winid)
+  if not view then
+    return false
+  end
+
+  local target_win = view.winid or winid or state.winid
+  store_saved_view(state.source_bufnr, target_win, view)
+  return true
+end
+
+function M.restore_source_view(source_bufnr, winid)
+  source_bufnr = normalize_bufnr(source_bufnr)
+  winid = winid or vim.api.nvim_get_current_win()
+  local saved = get_saved_view(source_bufnr, winid)
+  if not saved or saved.applied then
+    return false
+  end
+  if not snapshot_changedtick_matches(saved, source_bufnr) then
+    clear_saved_view(source_bufnr, winid)
+    return false
+  end
+  if not saved.enter_recorded and vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == source_bufnr then
+    local ok, live = pcall(vim.api.nvim_win_call, winid, function()
+      return vim.fn.winsaveview()
+    end)
+    if ok and type(live) == "table" then
+      saved.enter_lnum = live.lnum
+      saved.enter_recorded = true
+    end
+  end
+  if not apply_source_view(source_bufnr, winid, saved) then
+    return false
+  end
+  saved.applied = true
+  return true
+end
+
+function M.invalidate_source_view(source_bufnr, winid)
+  source_bufnr = normalize_bufnr(source_bufnr)
+  winid = tonumber(winid)
+  local by_win = saved_views[source_bufnr]
+  if not by_win then
+    return false
+  end
+
+  local tick = vim.api.nvim_buf_is_valid(source_bufnr) and vim.api.nvim_buf_get_changedtick(source_bufnr) or nil
+  local function stale(saved)
+    return not saved.source_changedtick or not tick or saved.source_changedtick ~= tick
+  end
+
+  if not winid then
+    local cleared = false
+    for saved_win, saved in pairs(by_win) do
+      if stale(saved) then
+        by_win[saved_win] = nil
+        cleared = true
+      end
+    end
+    if next(by_win) == nil then
+      saved_views[source_bufnr] = nil
+    end
+    return cleared
+  end
+
+  local saved = by_win[winid]
+  if not saved then
+    return false
+  end
+  if stale(saved) then
+    clear_saved_view(source_bufnr, winid)
+    return true
+  end
+  if not vim.api.nvim_win_is_valid(winid) or vim.api.nvim_win_get_buf(winid) ~= source_bufnr then
+    return false
+  end
+  local ok, view = pcall(vim.api.nvim_win_call, winid, function()
+    return vim.fn.winsaveview()
+  end)
+  if not ok or type(view) ~= "table" then
+    return false
+  end
+  if saved.applied then
+    if view.lnum ~= saved.source_lnum then
+      clear_saved_view(source_bufnr, winid)
+      return true
+    end
+    return false
+  end
+  if saved.enter_recorded and view.lnum ~= saved.enter_lnum then
+    clear_saved_view(source_bufnr, winid)
+    return true
+  end
+  return false
+end
+
 function M.is_reader(bufnr)
   bufnr = normalize_bufnr(bufnr)
   if not vim.api.nvim_buf_is_valid(bufnr) then
@@ -430,14 +773,48 @@ function M.source_changedtick(reader_bufnr)
   return state.source_changedtick
 end
 
-function M.open(source_bufnr, config)
+function M.open(source_bufnr, config, opts)
+  opts = opts or {}
   source_bufnr = normalize_bufnr(source_bufnr)
   if not vim.api.nvim_buf_is_valid(source_bufnr) or M.is_reader(source_bufnr) then
     return nil
   end
 
   local winid = vim.api.nvim_get_current_win()
-  local source_cursor = vim.api.nvim_win_get_cursor(winid)
+  local saved = nil
+  if opts.auto then
+    saved = get_saved_view(source_bufnr, winid)
+    if saved and not snapshot_changedtick_matches(saved, source_bufnr) then
+      clear_saved_view(source_bufnr, winid)
+      saved = nil
+    elseif saved and not saved.applied then
+      local live = vim.api.nvim_win_call(winid, function()
+        return vim.fn.winsaveview()
+      end)
+      if saved.enter_recorded and live.lnum ~= saved.enter_lnum then
+        clear_saved_view(source_bufnr, winid)
+        saved = nil
+      elseif apply_source_view(source_bufnr, winid, saved) then
+        saved.applied = true
+      end
+    end
+  else
+    clear_saved_view(source_bufnr, winid)
+  end
+
+  local source_view = vim.api.nvim_win_call(winid, function()
+    return vim.fn.winsaveview()
+  end)
+  if
+    opts.auto
+    and saved
+    and snapshot_changedtick_matches(saved, source_bufnr)
+    and source_view_matches_snapshot(source_view, saved)
+  then
+    source_view.cursor_offset = saved.cursor_offset
+    source_view.topline_offset = saved.topline_offset
+  end
+  local source_cursor = { source_view.lnum, source_view.col }
   local source_alt_bufnr = vim.fn.bufnr("#")
   local source_options = {
     wrap = vim.wo[winid].wrap,
@@ -502,9 +879,7 @@ function M.open(source_bufnr, config)
   end
   local finalized, finalize_error = pcall(function()
     configure_window(winid, config)
-    local reader_lnum = built.source_to_reader[source_cursor[1]] or 1
-    local reader_line = built.lines[reader_lnum] or ""
-    vim.api.nvim_win_set_cursor(winid, { reader_lnum, math.min(source_cursor[2], #reader_line) })
+    restore_reader_view(winid, built, source_view)
     M.update_sticky_header(reader_bufnr, winid)
   end)
   if not finalized then
@@ -553,8 +928,12 @@ function M.close(reader_bufnr)
     return state.source_bufnr
   end
 
-  local reader_cursor = vim.api.nvim_win_get_cursor(winid)
-  local source_lnum, source_col = source_cursor_for(state, reader_cursor[1], reader_cursor[2])
+  local view = capture_view(reader_bufnr, winid)
+  local fallback_lnum, fallback_col
+  if not view then
+    local reader_cursor = vim.api.nvim_win_get_cursor(winid)
+    fallback_lnum, fallback_col = source_cursor_for(state, reader_cursor[1], reader_cursor[2])
+  end
   -- The Reader mirrors source's modified flag so :x and ZZ save correctly.
   -- Clear only the disposable mirror before switching away from this view.
   vim.bo[reader_bufnr].modified = false
@@ -569,7 +948,14 @@ function M.close(reader_bufnr)
   end
 
   restore_window(state)
-  vim.api.nvim_win_set_cursor(winid, { source_lnum, source_col })
+  if view then
+    if not apply_source_view(state.source_bufnr, winid, view) then
+      pcall(vim.api.nvim_win_set_cursor, winid, { view.source_lnum, view.source_col })
+    end
+  elseif fallback_lnum then
+    pcall(vim.api.nvim_win_set_cursor, winid, { fallback_lnum, fallback_col })
+  end
+  clear_saved_view(state.source_bufnr, winid)
 
   states[reader_bufnr] = nil
   release_source(state, reader_bufnr)
@@ -817,6 +1203,8 @@ function M.abandon(reader_bufnr)
     return false
   end
 
+  M.sync_view(reader_bufnr)
+
   if vim.api.nvim_buf_is_valid(reader_bufnr) then
     M.clear_visual_selection(reader_bufnr)
     vim.bo[reader_bufnr].modified = false
@@ -847,20 +1235,21 @@ function M.abandon(reader_bufnr)
   return true
 end
 
-function M.cleanup(reader_bufnr)
-  local state = states[reader_bufnr]
+function M.cleanup(bufnr)
+  clear_saved_view(bufnr)
+  local state = states[bufnr]
   if state then
-    M.clear_visual_selection(reader_bufnr)
+    M.clear_visual_selection(bufnr)
     restore_window(state)
-    states[reader_bufnr] = nil
-    release_source(state, reader_bufnr)
+    states[bufnr] = nil
+    release_source(state, bufnr)
     return
   end
 
-  local source_state = source_states[reader_bufnr]
+  local source_state = source_states[bufnr]
   if source_state then
     local readers = vim.tbl_keys(source_state.readers)
-    source_states[reader_bufnr] = nil
+    source_states[bufnr] = nil
     for _, dependent in ipairs(readers) do
       local dependent_bufnr = dependent
       local dependent_state = states[dependent_bufnr]

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ were added:
 | GFM parsing | `parser_spec.lua` | delimiter validation, escaped/optional outer pipes, GFM missing-cell rows, fenced and block boundaries, linear large-document scanning |
 | Inline Markdown | `markdown_spec.lua`, `wrap_spec.lua` | code, emphasis, links, icons, concealed code delimiters, hard breaks, CJK width, preferred wrap boundaries, metadata preservation |
 | Geometry | `width_spec.lua`, `render_spec.lua` | display width, padding, alignment, border variants, source-row mapping, fit-to-window and intentional overflow |
-| Neovim views | `inline_spec.lua`, `reader_spec.lua`, `mode_spec.lua`, `lifecycle_spec.lua`, `multiwindow_spec.lua`, `cell_ops_spec.lua`, `reader_ergonomics_spec.lua`, `table_edit_spec.lua` | conceal/extmarks, wrap scope, viewport scrolling, per-buffer debounce/state, Reader policy, native buffer exits, shared-Source Readers, multiwindow resize fanout, transactional Reader open/refresh rollback, window option and lifetime cleanup, Source-aware cell registers/count rejection/native `c` motions/undo-redo repeat and visible Visual feedback, sticky headers, indexed cell lookup/refocus, narrow Reader snapshots, help ergonomics, explicit Source table rewrites, one-cell popup edits, and unsafe-table guards |
+| Neovim views | `inline_spec.lua`, `reader_spec.lua`, `mode_spec.lua`, `lifecycle_spec.lua`, `multiwindow_spec.lua`, `cell_ops_spec.lua`, `reader_ergonomics_spec.lua`, `table_edit_spec.lua` | conceal/extmarks, wrap scope, viewport scrolling, per-buffer debounce/state, Reader policy, native buffer exits with Reader/Inline scroll restore, shared-Source Readers, multiwindow resize fanout, transactional Reader open/refresh rollback, window option and lifetime cleanup, Source-aware cell registers/count rejection/native `c` motions/undo-redo repeat and visible Visual feedback, sticky headers, indexed cell lookup/refocus, narrow Reader snapshots, help ergonomics, explicit Source table rewrites, one-cell popup edits, and unsafe-table guards |
 | Context and actions | `context_spec.lua`, `actions_spec.lua`, `inspect_spec.lua` | Source resolution across modes, stable actions and Plug mappings, disabled/local mappings, passthrough, inspect/help/statusline, health diagnostics |
 | Links and mappings | `links_spec.lua`, `mappings_spec.lua` | relative/absolute files, line/anchor/wiki/image/URL targets, Float/Reader metadata, custom resolver, selector, callback/string/expr/remap/replace_keycodes restore semantics |
 | Interaction | `nav_spec.lua`, `config_spec.lua`, `system_spec.lua` | cell navigation, extracted command registration, isolated defaults/options, configuration validation, lazy-loading timing, and filetype boundaries |
@@ -64,8 +64,8 @@ plugins' extmarks are outside a headless process:
 11. Test at least one Linux terminal/compositor and one macOS terminal when
    changing overlay, conceal, or wrap behavior.
 12. Switch away from an automatically opened Reader with native buffer
-   navigation, return to its Source, and verify Reader reopens; explicit close
-   or edit must remain paused.
+   navigation, return to its Source, and verify Reader reopens at the same
+   cursor and scroll position; explicit close or edit must remain paused.
 13. Run `tests/benchmark.lua` and compare its scenarios with
     `docs/performance.md` on the same machine used for the release check.
 14. For large Reader or extmark changes, rerun the benchmark with

--- a/tests/spec/lifecycle_spec.lua
+++ b/tests/spec/lifecycle_spec.lua
@@ -633,6 +633,617 @@ h.test("returning to a Source after native buffer navigation restores automatic 
   delete_buffer(target_bufnr)
 end)
 
+h.test("native buffer navigation restores Reader cursor and topline", function()
+  local plugin = require("markdown-table-wrap")
+  local reader = require("markdown-table-wrap.reader")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({ auto_preview = true, preview_mode = "reader", debounce_ms = 0 })
+  vim.o.scrolloff = 0
+
+  local lines = {}
+  for index = 1, 40 do
+    table.insert(lines, "Paragraph line " .. index)
+  end
+  vim.list_extend(lines, {
+    "",
+    "| A | B |",
+    "| --- | --- |",
+    "| one | two |",
+  })
+
+  local source_bufnr = new_markdown_buffer(lines)
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  local winid = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_height(winid, 8)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local reader_bufnr = plugin.reader_preview()
+  h.assert_true("Reader opens for the tall Source", reader.is_reader(reader_bufnr))
+
+  vim.fn.winrestview({ lnum = 25, col = 0, topline = 18, leftcol = 0 })
+  local expected = vim.fn.winsaveview()
+  h.assert_eq("test cursor is away from the top", expected.lnum, 25)
+  h.assert_eq("test topline is away from the top", expected.topline, 18)
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(100, function()
+    return not vim.api.nvim_buf_is_valid(reader_bufnr)
+  end, 5)
+  h.assert_eq("native leave does not pause Source", plugin.state.paused_buffers[source_bufnr], nil)
+
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local source_view = vim.fn.winsaveview()
+  h.assert_eq("returning to Source restores cursor before Reader opens", source_view.lnum, 25)
+  h.assert_eq("returning to Source restores topline before Reader opens", source_view.topline, 18)
+
+  vim.wait(200, function()
+    return reader.is_reader(vim.api.nvim_get_current_buf())
+  end, 5)
+  h.assert_true("Reader reopens after returning to Source", reader.is_reader(vim.api.nvim_get_current_buf()))
+
+  local restored = vim.fn.winsaveview()
+  h.assert_eq("Reader cursor is restored", restored.lnum, expected.lnum)
+  h.assert_eq("Reader topline is restored", restored.topline, expected.topline)
+
+  plugin.close_reader()
+  plugin.state.paused_buffers[source_bufnr] = nil
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("native buffer navigation restores a wrapped Reader row offset", function()
+  local plugin = require("markdown-table-wrap")
+  local reader = require("markdown-table-wrap.reader")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({
+    auto_preview = true,
+    preview_mode = "reader",
+    debounce_ms = 0,
+    max_width_ratio = 1,
+    min_col_width = 4,
+    max_col_width = 16,
+  })
+  vim.o.scrolloff = 0
+
+  local source_bufnr = new_markdown_buffer({
+    "Before",
+    "| Name | Description |",
+    "| --- | --- |",
+    "| Row | content that wraps across several rendered rows |",
+    "After",
+  })
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  vim.api.nvim_win_set_width(0, 48)
+  vim.api.nvim_win_set_height(0, 6)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local reader_bufnr = plugin.reader_preview()
+  local built = reader._build(source_bufnr, plugin.get_buffer_config(source_bufnr))
+  local first = built.source_to_reader[4]
+  local wrapped = first
+  for lnum = first + 1, #built.lines do
+    if built.reader_to_source[lnum] ~= 4 then
+      break
+    end
+    wrapped = lnum
+  end
+  h.assert_true("wrapped Source row occupies extra Reader lines", wrapped > first)
+
+  vim.fn.winrestview({ lnum = wrapped, col = 0, topline = math.max(1, wrapped - 2), leftcol = 0 })
+  local expected = vim.fn.winsaveview()
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(100, function()
+    return not vim.api.nvim_buf_is_valid(reader_bufnr)
+  end, 5)
+
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.wait(200, function()
+    return reader.is_reader(vim.api.nvim_get_current_buf())
+  end, 5)
+  h.assert_true("Reader reopens after wrapped-row leave", reader.is_reader(vim.api.nvim_get_current_buf()))
+
+  local restored = vim.fn.winsaveview()
+  h.assert_eq("wrapped Reader cursor offset is restored", restored.lnum, expected.lnum)
+  h.assert_eq("wrapped Reader topline is restored", restored.topline, expected.topline)
+
+  plugin.close_reader()
+  plugin.state.paused_buffers[source_bufnr] = nil
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("leaving Reader does not jump another split of the same Source", function()
+  local plugin = require("markdown-table-wrap")
+  local reader = require("markdown-table-wrap.reader")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({ auto_preview = true, preview_mode = "reader", debounce_ms = 0 })
+  vim.o.scrolloff = 0
+
+  local lines = {}
+  for index = 1, 40 do
+    table.insert(lines, "Paragraph line " .. index)
+  end
+  vim.list_extend(lines, {
+    "",
+    "| A | B |",
+    "| --- | --- |",
+    "| one | two |",
+  })
+
+  local source_bufnr = new_markdown_buffer(lines)
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  local win_a = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_height(win_a, 8)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.cmd("vsplit")
+  local win_b = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_buf(win_b, source_bufnr)
+  vim.api.nvim_win_call(win_b, function()
+    vim.fn.winrestview({ lnum = 2, col = 0, topline = 1, leftcol = 0 })
+  end)
+  local split_view = vim.api.nvim_win_call(win_b, function()
+    return vim.fn.winsaveview()
+  end)
+
+  vim.api.nvim_set_current_win(win_a)
+  local reader_bufnr = plugin.reader_preview()
+  h.assert_true("Reader opens in the first window", reader.is_reader(reader_bufnr))
+  vim.fn.winrestview({ lnum = 25, col = 0, topline = 18, leftcol = 0 })
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(100, function()
+    return not vim.api.nvim_buf_is_valid(reader_bufnr)
+  end, 5)
+
+  local after = vim.api.nvim_win_call(win_b, function()
+    return vim.fn.winsaveview()
+  end)
+  h.assert_eq("other Source split keeps cursor", after.lnum, split_view.lnum)
+  h.assert_eq("other Source split keeps topline", after.topline, split_view.topline)
+
+  if vim.api.nvim_win_is_valid(win_b) then
+    vim.api.nvim_win_close(win_b, true)
+  end
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("moving in Source after restore is not overwritten by WinEnter or auto-reopen", function()
+  local plugin = require("markdown-table-wrap")
+  local reader = require("markdown-table-wrap.reader")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({ auto_preview = true, preview_mode = "reader", debounce_ms = 0 })
+  vim.o.scrolloff = 0
+
+  local lines = {}
+  for index = 1, 40 do
+    table.insert(lines, "Paragraph line " .. index)
+  end
+  vim.list_extend(lines, {
+    "",
+    "| A | B |",
+    "| --- | --- |",
+    "| one | two |",
+  })
+
+  local source_bufnr = new_markdown_buffer(lines)
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  local win_a = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_height(win_a, 8)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local reader_bufnr = plugin.reader_preview()
+  h.assert_true("Reader opens for movement test", reader.is_reader(reader_bufnr))
+  vim.fn.winrestview({ lnum = 25, col = 0, topline = 18, leftcol = 0 })
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(100, function()
+    return not vim.api.nvim_buf_is_valid(reader_bufnr)
+  end, 5)
+
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local restored_source = vim.fn.winsaveview()
+  h.assert_eq("Source cursor is restored once", restored_source.lnum, 25)
+
+  vim.fn.winrestview({ lnum = 3, col = 0, topline = 1, leftcol = 0 })
+  vim.api.nvim_win_set_cursor(win_a, { 3, 0 })
+
+  vim.cmd("vsplit")
+  local win_b = vim.api.nvim_get_current_win()
+  vim.api.nvim_set_current_win(win_a)
+  local after_enter = vim.fn.winsaveview()
+  h.assert_eq("later WinEnter does not restore the stale snapshot", after_enter.lnum, 3)
+
+  vim.wait(200, function()
+    return reader.is_reader(vim.api.nvim_get_current_buf())
+  end, 5)
+  h.assert_true("Reader reopens after the Source move", reader.is_reader(vim.api.nvim_get_current_buf()))
+  local reopened = vim.fn.winsaveview()
+  h.assert_eq("auto-reopen follows the moved Source cursor", reopened.lnum, 3)
+
+  plugin.close_reader()
+  plugin.state.paused_buffers[source_bufnr] = nil
+  if vim.api.nvim_win_is_valid(win_b) then
+    vim.api.nvim_win_close(win_b, true)
+  end
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("wrapped Reader offset is dropped when Source lnum no longer matches", function()
+  local plugin = require("markdown-table-wrap")
+  local reader = require("markdown-table-wrap.reader")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({
+    auto_preview = true,
+    preview_mode = "reader",
+    debounce_ms = 0,
+    max_width_ratio = 1,
+    min_col_width = 4,
+    max_col_width = 16,
+  })
+  vim.o.scrolloff = 0
+
+  local source_bufnr = new_markdown_buffer({
+    "Before",
+    "| Name | Description |",
+    "| --- | --- |",
+    "| Row | content that wraps across several rendered rows |",
+    "After",
+  })
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  vim.api.nvim_win_set_width(0, 48)
+  vim.api.nvim_win_set_height(0, 6)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local reader_bufnr = plugin.reader_preview()
+  local built = reader._build(source_bufnr, plugin.get_buffer_config(source_bufnr))
+  local first = built.source_to_reader[4]
+  local wrapped = first
+  for lnum = first + 1, #built.lines do
+    if built.reader_to_source[lnum] ~= 4 then
+      break
+    end
+    wrapped = lnum
+  end
+  h.assert_true("wrapped Source row occupies extra Reader lines", wrapped > first)
+
+  vim.fn.winrestview({ lnum = wrapped, col = 0, topline = math.max(1, wrapped - 2), leftcol = 0 })
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(100, function()
+    return not vim.api.nvim_buf_is_valid(reader_bufnr)
+  end, 5)
+
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.fn.winrestview({ lnum = 1, col = 0, topline = 1, leftcol = 0 })
+  vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+  vim.wait(200, function()
+    return reader.is_reader(vim.api.nvim_get_current_buf())
+  end, 5)
+  h.assert_true("Reader reopens after Source moved off the wrapped row", reader.is_reader(vim.api.nvim_get_current_buf()))
+
+  local restored = vim.fn.winsaveview()
+  local expected_lnum = built.source_to_reader[1] or 1
+  h.assert_eq("Reader follows the moved Source line", restored.lnum, expected_lnum)
+  h.assert_true("wrapped row offset is not reused", restored.lnum ~= wrapped)
+
+  plugin.close_reader()
+  plugin.state.paused_buffers[source_bufnr] = nil
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("inline preview keeps window view across buffer switches", function()
+  local plugin = require("markdown-table-wrap")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({
+    auto_preview = true,
+    preview_mode = "inline",
+    render_all = true,
+    debounce_ms = 0,
+  })
+  vim.o.scrolloff = 0
+
+  local lines = {}
+  for index = 1, 40 do
+    table.insert(lines, "Paragraph line " .. index)
+  end
+  vim.list_extend(lines, {
+    "",
+    "| A | B |",
+    "| --- | --- |",
+    "| one | two |",
+  })
+
+  local source_bufnr = new_markdown_buffer(lines)
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  vim.api.nvim_win_set_height(0, 8)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.wait(100, function()
+    return require("markdown-table-wrap.inline").is_active(source_bufnr)
+  end, 5)
+
+  vim.fn.winrestview({ lnum = 25, col = 0, topline = 18, leftcol = 0 })
+  local expected = vim.fn.winsaveview()
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(30)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.wait(150, function()
+    return vim.fn.winsaveview().topline == expected.topline
+      and vim.fn.winsaveview().lnum == expected.lnum
+  end, 5)
+
+  local restored = vim.fn.winsaveview()
+  h.assert_eq("inline cursor survives native leave", restored.lnum, expected.lnum)
+  h.assert_eq("inline topline survives native leave", restored.topline, expected.topline)
+
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("inline preview keeps window view across window switches", function()
+  local plugin = require("markdown-table-wrap")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({
+    auto_preview = true,
+    preview_mode = "inline",
+    render_all = true,
+    debounce_ms = 0,
+  })
+  vim.o.scrolloff = 0
+
+  local lines = {}
+  for index = 1, 40 do
+    table.insert(lines, "Paragraph line " .. index)
+  end
+  vim.list_extend(lines, {
+    "",
+    "| A | B |",
+    "| --- | --- |",
+    "| one | two |",
+  })
+
+  local source_bufnr = new_markdown_buffer(lines)
+  local win_a = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_height(win_a, 8)
+  vim.api.nvim_win_set_buf(win_a, source_bufnr)
+  vim.wait(100, function()
+    return require("markdown-table-wrap.inline").is_active(source_bufnr)
+  end, 5)
+
+  vim.fn.winrestview({ lnum = 25, col = 0, topline = 18, leftcol = 0 })
+  local expected = vim.fn.winsaveview()
+
+  vim.cmd("vsplit")
+  local win_b = vim.api.nvim_get_current_win()
+  vim.api.nvim_set_current_win(win_a)
+  vim.wait(150, function()
+    return vim.fn.winsaveview().topline == expected.topline
+      and vim.fn.winsaveview().lnum == expected.lnum
+  end, 5)
+
+  local restored = vim.fn.winsaveview()
+  h.assert_eq("inline cursor survives WinLeave", restored.lnum, expected.lnum)
+  h.assert_eq("inline topline survives WinLeave", restored.topline, expected.topline)
+
+  if vim.api.nvim_win_is_valid(win_b) then
+    vim.api.nvim_win_close(win_b, true)
+  end
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+end)
+
+h.test("leftover inline snapshot does not jump scroll on a later refresh", function()
+  local plugin = require("markdown-table-wrap")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({
+    auto_preview = true,
+    preview_mode = "inline",
+    render_all = true,
+    debounce_ms = 0,
+  })
+  vim.o.scrolloff = 0
+
+  local lines = {}
+  for index = 1, 40 do
+    table.insert(lines, "Paragraph line " .. index)
+  end
+  vim.list_extend(lines, {
+    "",
+    "| A | B |",
+    "| --- | --- |",
+    "| one | two |",
+  })
+
+  local source_bufnr = new_markdown_buffer(lines)
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  vim.api.nvim_win_set_height(0, 8)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.wait(100, function()
+    return require("markdown-table-wrap.inline").is_active(source_bufnr)
+  end, 5)
+
+  vim.fn.winrestview({ lnum = 25, col = 0, topline = 18, leftcol = 0 })
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(30)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.wait(100, function()
+    return require("markdown-table-wrap.inline").is_active(source_bufnr)
+  end, 5)
+
+  vim.fn.winrestview({ lnum = 3, col = 0, topline = 1, leftcol = 0 })
+  vim.api.nvim_win_set_cursor(0, { 3, 0 })
+  plugin.refresh_auto({ force = true })
+
+  local after_refresh = vim.fn.winsaveview()
+  h.assert_eq("refresh does not replay the leave snapshot cursor", after_refresh.lnum, 3)
+  h.assert_eq("refresh does not replay the leave snapshot topline", after_refresh.topline, 1)
+
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("wrapped Reader offset is restored when scrolloff adjusts topline", function()
+  local plugin = require("markdown-table-wrap")
+  local reader = require("markdown-table-wrap.reader")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({
+    auto_preview = true,
+    preview_mode = "reader",
+    debounce_ms = 0,
+    max_width_ratio = 1,
+    min_col_width = 4,
+    max_col_width = 16,
+  })
+  vim.o.scrolloff = 3
+
+  local source_bufnr = new_markdown_buffer({
+    "Before",
+    "| Name | Description |",
+    "| --- | --- |",
+    "| Row | content that wraps across several rendered rows |",
+    "After",
+  })
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  vim.api.nvim_win_set_width(0, 48)
+  vim.api.nvim_win_set_height(0, 8)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local reader_bufnr = plugin.reader_preview()
+  local built = reader._build(source_bufnr, plugin.get_buffer_config(source_bufnr))
+  local first = built.source_to_reader[4]
+  local wrapped = first
+  for lnum = first + 1, #built.lines do
+    if built.reader_to_source[lnum] ~= 4 then
+      break
+    end
+    wrapped = lnum
+  end
+  h.assert_true("wrapped Source row occupies extra Reader lines", wrapped > first)
+
+  vim.fn.winrestview({ lnum = wrapped, col = 0, topline = math.max(1, wrapped - 2), leftcol = 0 })
+  local expected = vim.fn.winsaveview()
+  h.assert_eq("scrolloff keeps the wrapped Reader cursor", expected.lnum, wrapped)
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(100, function()
+    return not vim.api.nvim_buf_is_valid(reader_bufnr)
+  end, 5)
+
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.wait(200, function()
+    return reader.is_reader(vim.api.nvim_get_current_buf())
+  end, 5)
+  h.assert_true("Reader reopens after scrolloff leave", reader.is_reader(vim.api.nvim_get_current_buf()))
+
+  local restored = vim.fn.winsaveview()
+  h.assert_eq("wrapped Reader cursor offset is restored with scrolloff", restored.lnum, expected.lnum)
+
+  plugin.close_reader()
+  plugin.state.paused_buffers[source_bufnr] = nil
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
+h.test("Source movement before the snapshot is applied wins over auto-reopen", function()
+  local plugin = require("markdown-table-wrap")
+  local reader = require("markdown-table-wrap.reader")
+  local original_scrolloff = vim.o.scrolloff
+
+  plugin.setup({ auto_preview = true, preview_mode = "reader", debounce_ms = 0 })
+  vim.o.scrolloff = 0
+
+  local lines = {}
+  for index = 1, 40 do
+    table.insert(lines, "Paragraph line " .. index)
+  end
+  vim.list_extend(lines, {
+    "",
+    "| A | B |",
+    "| --- | --- |",
+    "| one | two |",
+  })
+
+  local source_bufnr = new_markdown_buffer(lines)
+  local target_bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[target_bufnr].swapfile = false
+  vim.api.nvim_buf_set_lines(target_bufnr, 0, -1, false, { "temporary target" })
+
+  local winid = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_height(winid, 8)
+  vim.api.nvim_set_current_buf(source_bufnr)
+  local reader_bufnr = plugin.reader_preview()
+  h.assert_true("Reader opens for unapplied-movement test", reader.is_reader(reader_bufnr))
+  vim.fn.winrestview({ lnum = 25, col = 0, topline = 18, leftcol = 0 })
+
+  vim.api.nvim_set_current_buf(target_bufnr)
+  vim.wait(100, function()
+    return not vim.api.nvim_buf_is_valid(reader_bufnr)
+  end, 5)
+
+  -- Land on Source so the snapshot can record the pre-restore line, then move
+  -- before the deferred auto-reopen. A leftover unapplied snapshot must not
+  -- slam the Reader back to the leave position.
+  vim.api.nvim_set_current_buf(source_bufnr)
+  vim.fn.winrestview({ lnum = 3, col = 0, topline = 1, leftcol = 0 })
+  vim.api.nvim_win_set_cursor(winid, { 3, 0 })
+  reader.invalidate_source_view(source_bufnr, winid)
+
+  vim.wait(200, function()
+    return reader.is_reader(vim.api.nvim_get_current_buf())
+  end, 5)
+  h.assert_true("Reader reopens after Source movement before auto-reopen", reader.is_reader(vim.api.nvim_get_current_buf()))
+  local reopened = vim.fn.winsaveview()
+  h.assert_eq("auto-reopen follows Source movement made before auto-reopen", reopened.lnum, 3)
+
+  plugin.close_reader()
+  plugin.state.paused_buffers[source_bufnr] = nil
+  vim.o.scrolloff = original_scrolloff
+  delete_buffer(source_bufnr)
+  delete_buffer(target_bufnr)
+end)
+
 h.test("gx delegates ordinary text to the previous buffer-local mapping", function()
   local plugin = require("markdown-table-wrap")
   local fallback_calls = 0


### PR DESCRIPTION
## Summary
- Restore Reader cursor and window scroll across native buffer switches (`:Buffers`, `:bnext`, Telescope, and similar) by mapping the rendered viewport onto Source on leave and restoring it when Reader reopens.
- Preserve Inline window scroll when wrap/conceal options are restored on `BufLeave`/`BufWinEnter`.
- Cover the lifecycle behavior with tests and update changelog/docs.

## Test plan
- [ ] Open Reader, scroll away from the top, switch buffers with `:Buffers` / `:bnext` / Telescope, then return — confirm cursor and scroll restore
- [ ] Same check for Inline mode after buffer leave/re-enter
- [ ] Run `tests/spec/lifecycle_spec.lua`


Made with [Cursor](https://cursor.com)